### PR TITLE
feature/proxy_connector_for_test_of_ignore_fields

### DIFF
--- a/obp-api/pom.xml
+++ b/obp-api/pom.xml
@@ -8,7 +8,7 @@
     <groupId>com.tesobe</groupId>
     <artifactId>obp-parent</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>1.6.0</version>
+    <version>1.6.1</version>
   </parent>
   <artifactId>obp-api</artifactId>
   <packaging>war</packaging>

--- a/obp-api/src/main/scala/code/api/util/CustomJsonFormats.scala
+++ b/obp-api/src/main/scala/code/api/util/CustomJsonFormats.scala
@@ -12,9 +12,11 @@ import code.util.JsonUtils
 import com.openbankproject.commons.util.Functions.Memo
 import com.openbankproject.commons.util._
 import com.tesobe.CacheKeyFromArguments
+import net.liftweb.common.Box
 import net.liftweb.json
 import net.liftweb.json.JsonAST.JValue
 import net.liftweb.json.{TypeInfo, _}
+import net.liftweb.mapper.Mapper
 import org.apache.commons.lang3.StringUtils
 
 import scala.collection.immutable.List
@@ -29,11 +31,11 @@ trait CustomJsonFormats {
 
 object CustomJsonFormats {
 
-  val formats: Formats = JsonSerializers.commonFormats + ListResultSerializer
+  val formats: Formats = JsonSerializers.commonFormats + ListResultSerializer + MapperSerializer
 
-  val losslessFormats: Formats =  net.liftweb.json.DefaultFormats.lossless + ListResultSerializer ++ JsonSerializers.serializers
+  val losslessFormats: Formats =  net.liftweb.json.DefaultFormats.lossless + ListResultSerializer ++ JsonSerializers.serializers + MapperSerializer
 
-  val emptyHintFormats = DefaultFormats.withHints(ShortTypeHints(List())) + ListResultSerializer ++ JsonSerializers.serializers
+  val emptyHintFormats = DefaultFormats.withHints(ShortTypeHints(List())) + ListResultSerializer ++ JsonSerializers.serializers + MapperSerializer
 
   implicit val nullTolerateFormats = formats + JNothingSerializer
 
@@ -41,14 +43,14 @@ object CustomJsonFormats {
     val dateFormat = net.liftweb.json.DefaultFormats.dateFormat
 
     override val typeHints = ShortTypeHints(rolesMappedToClasses)
-  } + ListResultSerializer ++ JsonSerializers.serializers
+  } + ListResultSerializer ++ JsonSerializers.serializers + MapperSerializer
 }
 
 object ListResultSerializer extends Serializer[ListResult[_]] {
   private val clazz = classOf[ListResult[_]]
 
   def deserialize(implicit format: Formats): PartialFunction[(TypeInfo, JValue), ListResult[_]] = {
-    case (TypeInfo(entityType, Some(parameterizedType)), json) if(clazz.isAssignableFrom(entityType))=> json match {
+    case (TypeInfo(entityType, Some(parameterizedType)), json) if clazz.isAssignableFrom(entityType) => json match {
       case JObject(singleField::Nil) => {
         val resultsItemType = parameterizedType.getActualTypeArguments.apply(1)
         assume(resultsItemType != classOf[Object], "when do deserialize to type ListResult, should supply exactly type parameter, should not give wildcard like this: jValue.extract[ListResult[List[_]]]")
@@ -76,51 +78,46 @@ object ListResultSerializer extends Serializer[ListResult[_]] {
  * make tolerate for missing required constructor parameters
  */
 object JNothingSerializer extends Serializer[Any] with MdcLoggable {
+
   // This field is just a tag to declare all the missing fields are added, to avoid check missing field repeatedly
   val addedMissingFields = "addedMissingFieldsThisFieldIsJustBeTag"
 
+  private def addMissingFields(jObject: JObject, missingFieldNames: List[String]): JObject = {
+    val JObject(obj) = jObject
+    val newFields: List[JField] = obj ::: (addedMissingFields :: missingFieldNames).map(JField(_, JNull))
+    JObject(newFields)
+  }
+
+  private def isNoMissingFields(jValue: JValue): Boolean = (jValue \ addedMissingFields) != JNothing
+
   override def deserialize(implicit format: Formats): PartialFunction[(TypeInfo, JValue), Any] = {
-    case JNothingSerializer(typeInfo, jValue: JObject, missingFieldNames) if missingFieldNames.nonEmpty  => {
-      val newFields: List[JField] = jValue.obj ::: (addedMissingFields :: missingFieldNames).map(JField(_, JNull))
-      val newJValue =  JObject(newFields)
-      Extraction.extract(newJValue,typeInfo)
+    case JNothingSerializer(typeInfo, jValue: JObject, missingFieldNames) => {
+      val newJValue =  addMissingFields(jValue, missingFieldNames)
+      Extraction.extract(newJValue, typeInfo)
     }
   }
 
-  override def serialize(implicit format: Formats): PartialFunction[Any, JValue] = {
-    case null => JNull
-  }
+  override def serialize(implicit format: Formats): PartialFunction[Any, JValue] = Functions.doNothing
+
 
   private[this] def unapply(arg: (TypeInfo, JValue))(implicit formats: Formats): Option[(TypeInfo, JValue, List[String])] =  {
     val (TypeInfo(clazz, _), jValue) = arg
-    if (!jValue.isInstanceOf[JObject]) {
-      None
-    } else if(jValue \ addedMissingFields != JNothing) {
-      None
-    } else if (clazz == classOf[Option[_]] || clazz == classOf[List[_]] || clazz == classOf[Set[_]] || clazz.isArray) {
-      None
-    } else if (clazz == classOf[Map[_, _]]) {
-      None
-    } else if (tuple_?(clazz) && formats.tuplesAsArrays) {
+    if (! ReflectUtils.isObpClass(clazz) || jValue == JNothing || jValue == JNull || isNoMissingFields(jValue)) {
       None
     } else {
-      val jsonFieldNames: Set[String] = jValue.asInstanceOf[JObject].obj.map(_.name).toSet
-      val missingFields: Option[List[String]] = missingFieldNames(clazz, jsonFieldNames)
+      val jsonFieldNames: Set[String] = jValue.asInstanceOf[JObject].obj.toSet[JField].collect {
+        case JField(name, v) if v != JNothing => name
+      }
 
-      missingFields.map(it => (arg._1, arg._2, it))
+      val missingFields: List[String] = missingFieldNames(clazz, jsonFieldNames)
+      missingFields match {
+        case Nil => None
+        case x => Some((arg._1, arg._2, x))
+      }
     }
   }
 
-  private[this] val TUPLE_PATTERN = Pattern.compile("scala.Tuple([1-9]|1\\d|2[0-2])")
-
-  private[this] def tuple_?(t: Type) = t match {
-    case clazz: Class[_] =>
-      TUPLE_PATTERN.matcher(clazz.getName()).matches()
-    case _ =>
-      false
-  }
-
-  private[this] def missingFieldNames(clazz: Class[_], jsonFieldNames: Set[String]): Option[List[String]] = {
+  private[this] def missingFieldNames(clazz: Class[_], jsonFieldNames: Set[String]): List[String] = {
     // cache 2 hours, the cache time can be very long, because the result will never be changed
     var cacheKey = (randomUUID().toString, randomUUID().toString, randomUUID().toString)
     CacheKeyFromArguments.buildCacheKey {
@@ -128,11 +125,11 @@ object JNothingSerializer extends Serializer[Any] with MdcLoggable {
 
         val constructors: Array[Constructor[_]] = clazz.getDeclaredConstructors()
         bestMatching(constructors, jsonFieldNames) match {
-          case None => None
-          case Some(array: Array[Arg]) => {
-            val missingFields: Array[String] = array.map(_.path).filterNot(jsonFieldNames.contains(_))
-            if(missingFields.isEmpty) None else Some(missingFields.toList)
-          }
+          case None => Nil
+          case Some(array: Array[Arg]) =>
+            array.toList collect {
+              case arg if arg.required && !jsonFieldNames.contains(arg.path) => arg.path
+            }
         }
 
       }
@@ -156,11 +153,9 @@ object JNothingSerializer extends Serializer[Any] with MdcLoggable {
 
     val maybeObject: Option[Array[Arg]] = if (constructors.isEmpty) {
       None
-    }
-    else if(constructors.size == 1) {
+    } else if(constructors.size == 1) {
       constructors.headOption.map(_.getParameters.map(Arg(_)))
-    }
-    else {
+    } else {
       val choices: Array[Array[Arg]] = constructors.map(_.getParameters())
         .map(_.map(Arg(_)))
 
@@ -187,7 +182,14 @@ object JNothingSerializer extends Serializer[Any] with MdcLoggable {
       )
     }
     val path = parameter.getName()
-    val optional = classOf[Option[_]].isAssignableFrom(parameter.getType())
+
+    val optional = {
+      val optionClass: Class[Option[_]] = classOf[Option[_]]
+      val boxClass: Class[Box[_]] = classOf[Box[_]]
+      val paramType = parameter.getType()
+      optionClass.isAssignableFrom(paramType) || boxClass.isAssignableFrom(paramType)
+    }
+    val required = !optional
   }
 }
 
@@ -206,15 +208,21 @@ object FieldIgnoreSerializer extends Serializer[AnyRef] {
     case x if isInOutBoundType(x) && threadLocal.get() == null =>
       threadLocal.set(x)
       try{
-        val ignoreFieldNames: List[String] = getIgnores(ReflectUtils.getType(x)) ::: propsConfigIgnoreFields
-        val zson = json.Extraction.decompose(x)
-        ignoreFieldNames match {
-          case Nil => zson
-          case ignores => JsonUtils.deleteFields(zson, ignores)
-        }
+        toIgnoreFieldJson(x)
       } finally {
         threadLocal.remove()
       }
+  }
+
+  def toIgnoreFieldJson(x: Any)(implicit formats: Formats): JValue = toIgnoreFieldJson(x, ReflectUtils.getType(x))
+
+  def toIgnoreFieldJson(x: Any, tp: universe.Type, ignoreFunc: List[String] => List[String] = Functions.unary)(implicit formats: Formats): JValue = {
+    val ignoreFieldNames: List[String] = getIgnores(tp) ::: propsConfigIgnoreFields
+    val zson = json.Extraction.decompose(x)
+    ignoreFieldNames match {
+      case Nil => zson
+      case ignores => JsonUtils.deleteFields(zson, ignoreFunc(ignores))
+    }
   }
 
   private def isInOutBoundType(any: Any) = {
@@ -252,4 +260,34 @@ object FieldIgnoreSerializer extends Serializer[AnyRef] {
   }
 }
 
+/**
+ * serialize DB Mapped object to JValue
+ */
+object MapperSerializer extends Serializer[Mapper[_]] {
+  /**
+   * `call by name` method names those defined in Mapper trait.
+   */
+  val mapperMethods: Set[String] = typeOf[Mapper[_]].decls.filter(it => it.isMethod && it.asMethod.paramLists.isEmpty).map(_.name.decodedName.toString).toSet
 
+  private val memo = new Memo[universe.Type, Iterable[universe.MethodSymbol]]
+
+  override def serialize(implicit format: Formats): PartialFunction[Any, json.JValue] = {
+    case x: Mapper[_] =>
+      val tp: universe.Type = ReflectUtils.getType(x)
+      val instanceMirror: InstanceMirror = ReflectUtils.getInstanceMirror(x)
+      val callByNameMethods = memo.memoize(tp) {
+        tp.decls.filter(it => it.isMethod && it.overrides.nonEmpty && it.asMethod.paramLists.isEmpty && !mapperMethods.contains(it.name.decodedName.toString))
+          .map(_.asMethod)
+      }
+      // mapper object to Map[String, _]
+      val map: Map[String, Any] = callByNameMethods.map(method => {
+        val methodName = method.name.decodedName.toString
+        val value = instanceMirror.reflectMethod(method).apply()
+        methodName -> value
+      }).toMap
+      json.Extraction.decompose(map)
+  }
+
+
+  override def deserialize(implicit format: Formats): PartialFunction[(TypeInfo, json.JValue), Mapper[_]] = Functions.doNothing
+}

--- a/obp-api/src/main/scala/code/bankconnectors/Connector.scala
+++ b/obp-api/src/main/scala/code/bankconnectors/Connector.scala
@@ -91,7 +91,9 @@ object Connector extends SimpleInjector {
     "kafka_vSept2018" -> lazyValue(KafkaMappedConnector_vSept2018),
     "kafka_vMay2019" -> lazyValue(KafkaMappedConnector_vMay2019),
     "rest_vMar2019" -> lazyValue(RestConnector_vMar2019),
-    "stored_procedure_vDec2019" -> lazyValue(StoredProcedureConnector_vDec2019)
+    "stored_procedure_vDec2019" -> lazyValue(StoredProcedureConnector_vDec2019),
+    // this proxy connector only for unit test, can set connector=proxy in test.default.props, but never set itin default.props
+    "proxy" -> lazyValue(ConnectorUtils.proxyConnector)
   )
 
   def getConnectorInstance(connectorVersion: String): Connector = {

--- a/obp-api/src/main/scala/code/bankconnectors/ConnectorUtils.scala
+++ b/obp-api/src/main/scala/code/bankconnectors/ConnectorUtils.scala
@@ -1,0 +1,64 @@
+package code.bankconnectors
+
+import java.lang.reflect.Method
+
+import code.api.util.{CallContext, FieldIgnoreSerializer}
+import com.openbankproject.commons.ExecutionContext.Implicits.global
+import com.openbankproject.commons.dto.InBoundTrait
+import com.openbankproject.commons.util.ReflectUtils
+import net.liftweb.common.Full
+import net.liftweb.json.JsonDSL._
+import net.liftweb.json.{Formats, JValue}
+import net.sf.cglib.proxy.{Enhancer, MethodInterceptor, MethodProxy}
+import org.apache.commons.lang3.StringUtils
+
+import scala.concurrent.Future
+import scala.reflect.ManifestFactory
+
+object ConnectorUtils {
+
+  lazy val proxyConnector: Connector = {
+    val excludeProxyMethods = Set("getDynamicEndpoints", "dynamicEntityProcess", "setAccountHolder", "updateUserAccountViewsOld")
+
+    val intercept:MethodInterceptor = (_: Any, method: Method, args: Array[AnyRef], _: MethodProxy) => {
+      val originResult: AnyRef = method.invoke(LocalMappedConnector, args:_*)
+
+
+      val methodName = method.getName
+      val inBoundType: Option[Class[_]] = ReflectUtils.forClassOption(s"com.openbankproject.commons.dto.InBound${methodName.capitalize}")
+      if (!methodName.contains("$default$") && inBoundType.isDefined && !excludeProxyMethods.contains(methodName)) {
+        deleteIgnoreFieldValue(originResult, inBoundType.orNull).asInstanceOf[AnyRef]
+      } else {
+        originResult
+      }
+
+    }
+    val enhancer: Enhancer = new Enhancer()
+    enhancer.setSuperclass(classOf[Connector])
+    enhancer.setCallback(intercept)
+    enhancer.create().asInstanceOf[Connector]
+  }
+
+  private def deleteIgnoreFieldValue(obj: Any, inBoundClass: Class[_]): Any = obj match {
+    case x: Future[_] => x.map(deleteIgnoreFieldValue(_, inBoundClass))
+    case x @(Full(v), _: Option[CallContext]) => x.copy(_1 = Full(deleteIgnoreFields(v, inBoundClass)))
+    case x @(v, _: Option[CallContext]) => x.copy(_1 = deleteIgnoreFields(v, inBoundClass))
+    case Full((v, cc: Option[CallContext])) => Full(deleteIgnoreFields(v, inBoundClass) -> cc)
+    case Full(v) => Full(deleteIgnoreFields(v, inBoundClass))
+    case v => deleteIgnoreFields(v, inBoundClass)
+  }
+
+  private def deleteIgnoreFields(obj: Any, inBoundClass:  Class[_]): Any = {
+    implicit val formats: Formats = LocalMappedConnector.formats
+    def processIgnoreFields(fields: List[String]): List[String] = fields.collect {
+      case x if x.startsWith("data.") => StringUtils.substringAfter(x, "data.")
+    }
+    val zson = FieldIgnoreSerializer.toIgnoreFieldJson(obj, ReflectUtils.classToType(inBoundClass), processIgnoreFields)
+
+    val jObj: JValue = "data" -> zson
+
+    val mainFest = ManifestFactory.classType[InBoundTrait[Any]](inBoundClass)
+    jObj.extract[InBoundTrait[Any]](formats, mainFest).data
+  }
+
+}

--- a/obp-api/src/main/scala/code/util/JsonUtils.scala
+++ b/obp-api/src/main/scala/code/util/JsonUtils.scala
@@ -544,7 +544,7 @@ object JsonUtils {
       case JNull | JNothing => jValue
       case _: JObject =>
         if(!fieldName.contains(".")) {
-          jValue.removeField(_.name == fieldName)
+          deleteField(jValue)(_.name == fieldName)
         } else {
           val Array(field, nestedField) = StringUtils.split(fieldName, ".", 2)
           jValue.transformField {
@@ -554,4 +554,41 @@ object JsonUtils {
       case JArray(arr) => JArray(arr.map(deleteField(_, fieldName)))
     }
 
+  /**
+   * recursive delete fields of JValue.
+   * what different between this function with net.liftweb.json.JsonAST.JValue#removeField:
+   * this function delete fields, removeField function set field's value to JNothing, this cause error when do deserialization
+   * @param jValue to delete fields json
+   * @param p checker of whether delete given field.
+   * @return deleted some fields json
+   */
+  def deleteFieldRec(jValue:JValue)(p: JField => Boolean): JValue = {
+    def rec(v: JValue): JValue = v match {
+      case JObject(l) => JObject(l.collect {
+        case field @JField(_, value) if !p(field) => field.copy(value = rec(value))
+      })
+      case JArray(l) => JArray(l.map(rec))
+      case x => x
+    }
+    rec(jValue)
+  }
+
+  /**
+   * delete fields of JValue.
+   * what different between this function with net.liftweb.json.JsonAST.JValue#removeField:
+   * this function not delete nested fields, removeField function recursive set field's value to JNothing, this cause error when do deserialization
+   * @param jValue to delete fields json
+   * @param p checker of whether delete given field.
+   * @return deleted some fields json
+   */
+  def deleteField(jValue:JValue)(p: JField => Boolean): JValue = {
+    def deleteFunc(v: JValue): JValue = v match {
+      case JObject(l) => JObject(l.collect {
+        case field if !p(field) => field
+      })
+      case JArray(l) => JArray(l.map(deleteFunc))
+      case x => x
+    }
+    deleteFunc(jValue)
+  }
 }

--- a/obp-commons/pom.xml
+++ b/obp-commons/pom.xml
@@ -7,7 +7,7 @@
         <groupId>com.tesobe</groupId>
         <artifactId>obp-parent</artifactId>
         <relativePath>../pom.xml</relativePath>
-        <version>1.6.0</version>
+        <version>1.6.1</version>
     </parent>
     <artifactId>obp-commons</artifactId>
     <packaging>jar</packaging>

--- a/obp-commons/src/main/scala/com/openbankproject/commons/util/ReflectUtils.scala
+++ b/obp-commons/src/main/scala/com/openbankproject/commons/util/ReflectUtils.scala
@@ -487,6 +487,18 @@ object ReflectUtils {
 
   def forType(className: String): ru.Type = mirror.staticClass(className).toType
 
+  def forTypeOption(className: String): Option[ru.Type] = try {
+      Some(mirror.staticClass(className).toType)
+    } catch {
+      case _: ScalaReflectionException => None
+    }
+
+  def forClassOption(className: String): Option[Class[_]] = try {
+      Some(Class.forName(className, false, getClass().getClassLoader))
+    } catch {
+      case _: ClassNotFoundException => None
+    }
+
   def getPrimaryConstructor(tp: ru.Type): MethodSymbol = tp.decl(ru.termNames.CONSTRUCTOR).alternatives.head.asMethod
 
   def getPrimaryConstructor(obj: Any): MethodSymbol = this.getPrimaryConstructor(this.getType(obj))

--- a/obp-commons/src/main/scala/com/openbankproject/commons/util/ReflectUtils.scala
+++ b/obp-commons/src/main/scala/com/openbankproject/commons/util/ReflectUtils.scala
@@ -62,6 +62,8 @@ object ReflectUtils {
     result
   }
 
+  def getInstanceMirror(any: Any): ru.InstanceMirror = mirror.reflect(any)
+
   def getFieldValues(obj: AnyRef)(predicate: TermSymbol => Boolean = _=>true): Map[String, Any] = {
     val instanceMirror = mirror.reflect(obj)
     val tp: ru.Type = instanceMirror.symbol.info

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.tesobe</groupId>
   <artifactId>obp-parent</artifactId>
-  <version>1.6.0</version>
+  <version>1.6.1</version>
   <packaging>pom</packaging>
   <name>Open Bank Project API Parent</name>
   <inceptionYear>2011</inceptionYear>


### PR DESCRIPTION
Add proxy connector, it calls LocalMappedConnector and ignores fields in the return value.
Note: Never use this proxy connector at the product environment.
1. connector=proxy
2. comment out this, or set it's value to proxy: `#connector.name.export.as.endpoint=stored_procedure_vDec2019`
3. add @ignore or config props ignore fields, it can have type prefix, like the last one as follow:
```
inbound.ignore.fields= \
inboundAdapterCallContext.generalContext,\
inboundAdapterCallContext.sessionId,\
InBoundGetBanks:data.logoUrl
```
### Jenkins job is running, it is not ready to be merged.

----------------------
Jenkins jobs passed:
[JDK 8](https://jenkins.tesobe.com/job/Build-obp-api-shuang/306/)
[JDK 11](https://jenkins.tesobe.com/view/-Build/job/Build-OBP-API-shuang-jdk11/61/)
[JDK 13](https://jenkins.tesobe.com/job/Build-OBP-API-shuang-jdk13_UNLICENSED-JDK-NOT-FOR-DEPLOYMENT/167/)