### PR TITLE
build: replace tools.jackson 3.x yaml dep with com.fasterxml 2.x

### DIFF
--- a/obp-api/pom.xml
+++ b/obp-api/pom.xml
@@ -514,11 +514,12 @@
       <artifactId>jackson-databind</artifactId>
       <!-- version managed by jackson-bom in parent pom -->
     </dependency>
-      <!-- https://mvnrepository.com/artifact/tools.jackson.dataformat/jackson-dataformat-yaml -->
+    <!-- com.fasterxml YAML module (Jackson 2.x), version managed by jackson-bom in parent pom.
+         Replaces the incompatible tools.jackson 3.x line so a single Jackson generation is on
+         the classpath. YAMLUtils uses com.fasterxml.jackson.dataformat.yaml.YAMLFactory. -->
     <dependency>
-      <groupId>tools.jackson.dataformat</groupId>
+      <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-yaml</artifactId>
-      <version>3.0.4</version>
     </dependency>
     <!-- https://mvnrepository.com/artifact/com.squareup.okhttp3/okhttp -->
     <dependency>


### PR DESCRIPTION
## Problem

`obp-api/pom.xml` declared `tools.jackson.dataformat:jackson-dataformat-yaml:3.0.4`
alongside the jackson-bom-managed `com.fasterxml.jackson.*` 2.18.7 suite.
These two groupIds are from **different, incompatible Jackson generations** — they
cannot coexist on the same classpath without class-loading conflicts.

The actual call site (`YAMLUtils.scala`) uses `com.fasterxml.jackson.dataformat.yaml.YAMLFactory`,
so the `tools.jackson` 3.x artifact is not only wrong but completely unused.

## Fix

- Deleted `tools.jackson.dataformat:jackson-dataformat-yaml:3.0.4` from `obp-api/pom.xml`
- Added `com.fasterxml.jackson.dataformat:jackson-dataformat-yaml` (no explicit version —
  managed by the `jackson-bom` in parent `pom.xml` to 2.18.7)

## Verification

```
mvn dependency:tree -pl obp-api -am | grep jackson-dataformat-yaml
# Before: tools.jackson.dataformat:jackson-dataformat-yaml:jar:3.0.4:compile
# After:  com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:jar:2.18.7:compile
```

Local parallel test suite (`run_tests_parallel.sh --shards=4`): **✅ ALL SHARDS PASSED** (5m 16s, 2918 tests).

Fixes #7