### PR TITLE
build: remove redundant flexmark-util-options 0.64.0 dep

### DIFF
--- a/obp-api/pom.xml
+++ b/obp-api/pom.xml
@@ -312,7 +312,7 @@
       <artifactId>json-smart</artifactId>
     </dependency>
     <!-- ********** flexmark START ********** -->
-    <!-- Library flexmark-all v0.40.8 is replaced with used modules -->
+    <!-- Library flexmark-all v0.40.8 is replaced with used module -->
     <!-- https://mvnrepository.com/artifact/com.vladsch.flexmark/flexmark-profile-pegdown -->
     <dependency>
       <groupId>com.vladsch.flexmark</groupId>

--- a/obp-api/pom.xml
+++ b/obp-api/pom.xml
@@ -319,12 +319,7 @@
       <artifactId>flexmark-profile-pegdown</artifactId>
       <version>0.40.8</version>
     </dependency>
-    <!-- https://mvnrepository.com/artifact/com.vladsch.flexmark/flexmark-util-options -->
-    <dependency>
-      <groupId>com.vladsch.flexmark</groupId>
-      <artifactId>flexmark-util-options</artifactId>
-      <version>0.64.0</version>
-    </dependency>
+
       <!-- https://mvnrepository.com/artifact/org.web3j/core -->
       <dependency>
           <groupId>org.web3j</groupId>


### PR DESCRIPTION
## Problem

`obp-api/pom.xml` declared two incompatible flexmark versions simultaneously:

- `flexmark-profile-pegdown:0.40.8` — the required artifact (all call sites in `PegdownOptions.scala` use the `com.vladsch.flexmark.util.options.*` package from this version)
- `flexmark-util-options:0.64.0` — a redundant explicit declaration at a completely different version

The 0.64.x series ships `flexmark-util-options` as a separate artifact with a repackaged API incompatible with 0.40.x. Having both on the classpath risks class-loading conflicts at runtime for any code path that uses flexmark options.

## Fix

Deleted the explicit `flexmark-util-options:0.64.0` declaration from `obp-api/pom.xml`. The 0.40.8 transitive chain (`flexmark-profile-pegdown` → `flexmark-util`) provides all needed `com.vladsch.flexmark.util.options.*` classes.

## Verification

```
mvn dependency:tree -pl obp-api -am | grep flexmark
# All entries: com.vladsch.flexmark:*:jar:0.40.8 — no 0.64.x artifact remaining
```

Local parallel test suite (`run_tests_parallel.sh --shards=4`): **✅ ALL SHARDS PASSED** (2918 tests).

Fixes #8