### PR TITLE
build: upgrade avro4s to 4.1.2 and pin avro to 1.11.4 (fixes #17)

### DIFF
--- a/obp-api/pom.xml
+++ b/obp-api/pom.xml
@@ -117,7 +117,14 @@
       <artifactId>protobuf-java</artifactId>
       <version>3.25.5</version>
     </dependency>
-    <!-- Pin snappy-java to override the 1.1.1.3 pulled in transitively by avro 1.8.2.
+    <!-- Pin org.apache.avro:avro to 1.11.4 to override the 1.9.2 pulled in transitively
+         by avro4s 4.1.2. Fixes CVE-2024-47561 (CVSS 9.8 — RCE via schema parsing). -->
+    <dependency>
+      <groupId>org.apache.avro</groupId>
+      <artifactId>avro</artifactId>
+      <version>1.11.4</version>
+    </dependency>
+    <!-- Pin snappy-java to override older versions pulled in transitively by avro.
          Fixes CVE-2023-34453, CVE-2023-34454, CVE-2023-34455, CVE-2023-43642. -->
     <dependency>
       <groupId>org.xerial.snappy</groupId>

--- a/obp-api/pom.xml
+++ b/obp-api/pom.xml
@@ -122,7 +122,7 @@
     <dependency>
       <groupId>org.apache.avro</groupId>
       <artifactId>avro</artifactId>
-      <version>1.11.4</version>
+      <version>${apache.avro.version}</version>
     </dependency>
     <!-- Pin snappy-java to override older versions pulled in transitively by avro.
          Fixes CVE-2023-34453, CVE-2023-34454, CVE-2023-34455, CVE-2023-43642. -->
@@ -236,7 +236,7 @@
     <dependency>
       <groupId>com.sksamuel.avro4s</groupId>
       <artifactId>avro4s-core_${scala.version}</artifactId>
-      <version>${avro.version}</version>
+      <version>${avro4s.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/obp-api/src/main/scala/code/bankconnectors/AvroSerializer.scala
+++ b/obp-api/src/main/scala/code/bankconnectors/AvroSerializer.scala
@@ -32,7 +32,7 @@ trait AvroSerializer {
   }
 
   class StringInputStream(s: String) extends InputStream {
-    private val bytes = s.getBytes
+    private val bytes = s.getBytes("UTF-8")
 
     private var pos = 0
 
@@ -41,7 +41,7 @@ trait AvroSerializer {
     } else {
       val r = bytes(pos)
       pos += 1
-      r.toInt
+      r.toInt & 0xFF
     }
   }
 }

--- a/obp-api/src/main/scala/code/bankconnectors/AvroSerializer.scala
+++ b/obp-api/src/main/scala/code/bankconnectors/AvroSerializer.scala
@@ -5,33 +5,30 @@ import java.io.{ByteArrayOutputStream, InputStream}
 import com.sksamuel.avro4s._
 
 import scala.concurrent.{ExecutionContext, Future}
-import scala.util.Try
+import scala.util.Success
 
-/**
-  * Provides generic serialization/deserialization
-  */
 trait AvroSerializer {
 
-  def serialize[T: SchemaFor : ToRecord](event: T)(implicit executionContext: ExecutionContext): String = {
+  def serialize[T: Encoder](event: T)(implicit executionContext: ExecutionContext): String = {
     val baos = new ByteArrayOutputStream()
-    val output = AvroOutputStream.json[T](baos)
+    val output = AvroOutputStream.json[T].to(baos).build()
     output.write(event)
     output.close()
-    val r = baos.toString("UTF-8")
-    r
+    baos.toString("UTF-8")
   }
 
-  def serializeFuture[T: SchemaFor : ToRecord](event: T)(implicit executionContext: ExecutionContext): Future[String] =
+  def serializeFuture[T: Encoder](event: T)(implicit executionContext: ExecutionContext): Future[String] =
     Future(serialize(event))
 
-  def deserializeFuture[T >: Null : SchemaFor : FromRecord](data: String)(implicit executionContext: ExecutionContext): Future[Option[T]] =
+  def deserializeFuture[T >: Null : Decoder](data: String)(implicit executionContext: ExecutionContext): Future[Option[T]] =
     Future(deserialize[T](data))
 
-  def deserialize[T >: Null : SchemaFor : FromRecord](data: String)(implicit executionContext: ExecutionContext): Option[T] = {
-
-    val input = AvroInputStream.json[T](new StringInputStream(data))
-    val result: Try[T] = input.singleEntity
-    result.toOption
+  def deserialize[T >: Null : Decoder](data: String)(implicit executionContext: ExecutionContext): Option[T] = {
+    val schema = implicitly[Decoder[T]].schema
+    val input = AvroInputStream.json[T].from(new StringInputStream(data)).build(schema)
+    val result = input.tryIterator.collectFirst { case Success(v) => v }
+    input.close()
+    result
   }
 
   class StringInputStream(s: String) extends InputStream {

--- a/obp-api/src/main/scala/code/bankconnectors/akka/AkkaConnector_vDec2018.scala
+++ b/obp-api/src/main/scala/code/bankconnectors/akka/AkkaConnector_vDec2018.scala
@@ -18,7 +18,6 @@ import com.openbankproject.commons.dto._
 import com.openbankproject.commons.model._
 import com.openbankproject.commons.model.enums.StrongCustomerAuthenticationStatus.SCAStatus
 import com.openbankproject.commons.model.enums.{AccountAttributeType, CardAttributeType, ChallengeType, CustomerAttributeType, ProductAttributeType, StrongCustomerAuthentication, TransactionAttributeType, TransactionRequestStatus}
-import com.sksamuel.avro4s.SchemaFor
 import net.liftweb.common.{Box, Full}
 import com.openbankproject.commons.util.JsonAliases.parse
 
@@ -55,8 +54,8 @@ object AkkaConnector_vDec2018 extends Connector with AkkaConnectorActorInit {
         inboundStatus,
         inboundAdapterInfoInternal)
       ),
-    outboundAvroSchema = Some(parse(SchemaFor[OutBoundGetAdapterInfo]().toString(true))),
-    inboundAvroSchema = Some(parse(SchemaFor[InBoundGetAdapterInfo]().toString(true))),
+    outboundAvroSchema = None,
+    inboundAvroSchema = None,
     adapterImplementation = Some(AdapterImplementation("- Core", 1))
   )
   override def getAdapterInfo(callContext: Option[CallContext]): Future[Box[(InboundAdapterInfoInternal, Option[CallContext])]] = {
@@ -81,8 +80,8 @@ object AkkaConnector_vDec2018 extends Connector with AkkaConnectorActorInit {
         List(bankCommons)
       )
       ),
-    outboundAvroSchema = Some(parse(SchemaFor[OutBoundGetBanks]().toString(true))),
-    inboundAvroSchema =  Some(parse(SchemaFor[InBoundGetBanks]().toString(true))),
+    outboundAvroSchema = None,
+    inboundAvroSchema = None,
     adapterImplementation = Some(AdapterImplementation("- Core", 2))
   )
 
@@ -110,8 +109,8 @@ object AkkaConnector_vDec2018 extends Connector with AkkaConnectorActorInit {
         bankCommons
       )
       ),
-    outboundAvroSchema = Some(parse(SchemaFor[OutBoundGetBank]().toString(true))),
-    inboundAvroSchema = Some(parse(SchemaFor[InBoundGetBank]().toString(true))),
+    outboundAvroSchema = None,
+    inboundAvroSchema = None,
     adapterImplementation = Some(AdapterImplementation("- Core", 5))
   )
   override def getBank(bankId : BankId, callContext: Option[CallContext]): Future[Box[(Bank, Option[CallContext])]] = {

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,8 @@
     <scala.compiler>2.12.20</scala.compiler>
     <pekko.version>1.1.5</pekko.version>
     <pekko-http.version>1.1.0</pekko-http.version>
-    <avro.version>4.1.2</avro.version>
+    <avro4s.version>4.1.2</avro4s.version>
+    <apache.avro.version>1.11.4</apache.avro.version>
     <lift.version>v1.0.4</lift.version>
     <http4s.version>0.23.30</http4s.version>
     <!-- Common plugin settings -->

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <scala.compiler>2.12.20</scala.compiler>
     <pekko.version>1.1.5</pekko.version>
     <pekko-http.version>1.1.0</pekko-http.version>
-    <avro.version>1.8.2</avro.version>
+    <avro.version>4.1.2</avro.version>
     <lift.version>v1.0.4</lift.version>
     <http4s.version>0.23.30</http4s.version>
     <!-- Common plugin settings -->


### PR DESCRIPTION
## Summary

- Upgrades avro4s-core from 1.8.2 to 4.1.2 and pins `org.apache.avro:avro` to 1.11.4 to fix CVE-2024-47561 (CVSS 9.8 RCE)
- avro4s 4.1.2 only brings avro 1.9.2 transitively (still vulnerable), so the explicit avro pin is required
- Migrates `AvroSerializer.scala` to the avro4s 4.x streaming API (`Encoder`/`Decoder` context bounds, builder-style `AvroOutputStream`/`AvroInputStream`)
- Removes `SchemaFor[T]` usage from `AkkaConnector_vDec2018.scala` (documentation-only schema metadata fields; avro4s 4.x Magnolia derivation cannot auto-derive `SchemaFor` for the deep OBP DTO type hierarchies at compile time)

## Test plan

- [ ] `mvn compile -DskipTests -pl obp-api -am` passes with no errors
- [ ] `mvn dependency:resolve -pl obp-api` shows `org.apache.avro:avro:1.11.4` and `avro4s-core_2.12:4.1.2`
- [ ] CI tests pass (AvroSerializer is used only in the Akka/RabbitMQ connector path, which has no active test coverage in the local suite)