### PR TITLE
chore: remove httpclient direct dep and scope AHC to test

### DIFF
--- a/obp-api/pom.xml
+++ b/obp-api/pom.xml
@@ -173,11 +173,6 @@
       <version>3.3.0</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpclient</artifactId>
-      <version>4.5.14</version>
-    </dependency>
-    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-pool2</artifactId>
       <version>2.11.1</version>
@@ -412,6 +407,7 @@
       <groupId>org.asynchttpclient</groupId>
       <artifactId>async-http-client</artifactId>
       <version>2.15.0</version>
+      <scope>test</scope>
         <exclusions>
             <exclusion>
                 <artifactId>javax.activation</artifactId>

--- a/obp-api/src/main/scala/code/api/dynamic/endpoint/OBPAPIDynamicEndpoint.scala
+++ b/obp-api/src/main/scala/code/api/dynamic/endpoint/OBPAPIDynamicEndpoint.scala
@@ -33,7 +33,6 @@ import code.api.util.{APIUtil, VersionedOBPApis}
 import code.util.Helper.MdcLoggable
 import com.openbankproject.commons.util.{ApiVersion,ApiVersionStatus}
 import net.liftweb.common.{Box, Full}
-import org.apache.http.HttpStatus
 
 /*
 This file defines which endpoints from all the versions are available in v4.0.0

--- a/obp-api/src/main/scala/code/api/dynamic/endpoint/OBPAPIDynamicEndpoint.scala
+++ b/obp-api/src/main/scala/code/api/dynamic/endpoint/OBPAPIDynamicEndpoint.scala
@@ -28,11 +28,9 @@ package code.api.dynamic.endpoint
 
 import APIMethodsDynamicEndpoint.ImplementationsDynamicEndpoint
 import code.api.OBPRestHelper
-import code.api.dynamic.endpoint.helper.DynamicEndpoints
-import code.api.util.{APIUtil, VersionedOBPApis}
+import code.api.util.VersionedOBPApis
 import code.util.Helper.MdcLoggable
 import com.openbankproject.commons.util.{ApiVersion,ApiVersionStatus}
-import net.liftweb.common.{Box, Full}
 
 /*
 This file defines which endpoints from all the versions are available in v4.0.0


### PR DESCRIPTION
## Problem

After PR #9 removed dispatch-core, three HTTP clients remained in compile scope:
- `okhttp3:4.12.0` — actively used in production code (WebhookHttpClient, search.scala)
- `async-http-client:2.15.0` — declared in compile scope but only used by one test class
- `httpclient:4.5.14` — declared directly but the only reference was an unused import pointing at a commented-out call site

Having AHC in compile scope misleads developers into thinking it is a production dependency and increases the risk of it being used accidentally in production code instead of the canonical okhttp3.

## Root Cause

`org.apache.http.HttpStatus` was imported in `OBPAPIDynamicEndpoint.scala` but the call site that used it (`PlainTextResponse(..., HttpStatus.SC_NO_CONTENT)`) had already been commented out. The import was dead code. Once removed, `httpclient` has zero direct usages in main sources and does not need an explicit compile-scope declaration — it remains available transitively via `elasticsearch-rest-client` for Elasticsearch's own use.

`async-http-client` was declared in compile scope but its sole direct import (`import org.asynchttpclient.Response`) lives in `OPTIONSTest.scala`, a test class. Compile scope is incorrect for a test-only dependency.

## Changes

| File | Change |
|---|---|
| `obp-api/pom.xml` | Removed `org.apache.httpcomponents:httpclient:4.5.14` explicit declaration (still available transitively via elasticsearch-rest-client) |
| `obp-api/pom.xml` | Added `<scope>test</scope>` to `org.asynchttpclient:async-http-client:2.15.0` |
| `obp-api/src/main/scala/code/api/dynamic/endpoint/OBPAPIDynamicEndpoint.scala` | Removed unused `import org.apache.http.HttpStatus` |

## Verification

```
# httpclient still available transiently via elasticsearch (not "Used undeclared" in obp-api):
mvn dependency:analyze -pl obp-api → 0 Used undeclared warnings

# AHC scoped to test:
mvn dependency:tree -pl obp-api | grep asynchttpclient
→ org.asynchttpclient:async-http-client:jar:2.15.0:test

# httpclient still in tree (transitive, from elasticsearch-rest-client):
mvn dependency:tree -pl obp-api | grep httpclient
→ org.apache.httpcomponents:httpclient:jar:4.5.14:compile (via elasticsearch)

# Compile clean:
mvn compile -DskipTests -pl obp-api -am → BUILD SUCCESS
```

Local test suite (run_tests_parallel.sh --shards=4): in progress

## Rollback

```bash
git revert df13d40b8
git push Hongwei develop
```

Revert is safe — removes the `<scope>test</scope>` and restores the direct httpclient pin; no runtime behaviour changes in either direction.

Fixes #18