### PR TITLE
fix: await SCA payment status persistence, redact JWT secret log, raise default DB pool

### DIFF
--- a/obp-api/src/main/scala/bootstrap/liftweb/CustomDBVendor.scala
+++ b/obp-api/src/main/scala/bootstrap/liftweb/CustomDBVendor.scala
@@ -28,7 +28,10 @@ class CustomDBVendor(driverName: String,
     val config = new HikariConfig()
 
     val connectionTimeout = APIUtil.getPropsAsLongValue("hikari.connectionTimeout", 30000L)
-    val maximumPoolSize   = APIUtil.getPropsAsIntValue("hikari.maximumPoolSize", 10)
+    // Default 20: each request holds its transaction connection for its whole lifetime,
+    // so a pool of 10 exhausts at ~5 concurrent requests (rate-limit queries need a 2nd connection).
+    // Kept prop-overridable so ops can tune higher.
+    val maximumPoolSize   = APIUtil.getPropsAsIntValue("hikari.maximumPoolSize", 20)
     val idleTimeout       = APIUtil.getPropsAsLongValue("hikari.idleTimeout", 600000L)
     val keepaliveTime     = APIUtil.getPropsAsLongValue("hikari.keepaliveTime", 30000L)
     val maxLifetime       = APIUtil.getPropsAsLongValue("hikari.maxLifetime", 1800000L)

--- a/obp-api/src/main/scala/code/api/berlin/group/v1_3/Http4sBGv13PIS.scala
+++ b/obp-api/src/main/scala/code/api/berlin/group/v1_3/Http4sBGv13PIS.scala
@@ -624,7 +624,7 @@ object Http4sBGv13PIS extends MdcLoggable {
             )
             _ <- challenge.scaStatus match {
               case Some(status) if status == StrongCustomerAuthenticationStatus.finalised =>
-                NewStyle.function.createTransactionAfterChallengeV210(fromAccount, existingTransactionRequest, callContext) map { _ =>
+                NewStyle.function.createTransactionAfterChallengeV210(fromAccount, existingTransactionRequest, callContext) flatMap { _ =>
                   NewStyle.function.saveTransactionRequestStatusImpl(existingTransactionRequest.id, COMPLETED.toString, callContext)
                 }
               case Some(status) if status == StrongCustomerAuthenticationStatus.failed =>

--- a/obp-api/src/main/scala/code/api/util/JwtUtil.scala
+++ b/obp-api/src/main/scala/code/api/util/JwtUtil.scala
@@ -77,7 +77,7 @@ object JwtUtil extends MdcLoggable {
     * @return True or False
     */
   def verifyHmacSignedJwt(jwtToken: String, sharedSecret: String): Boolean = {
-    logger.debug(s"code.api.util.JwtUtil.verifyHmacSignedJwt beginning:: jwtToken($jwtToken), sharedSecret($sharedSecret)")
+    logger.debug("code.api.util.JwtUtil.verifyHmacSignedJwt beginning")
     val signedJWT = SignedJWT.parse(jwtToken)
     val verifier = new MACVerifier(sharedSecret)
     logger.debug(s"code.api.util.JwtUtil.verifyHmacSignedJwt beginning:: signedJWT($signedJWT)")


### PR DESCRIPTION
## Summary

First batch of low-risk stability fixes from the cross-verified stability audit. Three independent, high-value fixes that need no design work; the design-heavy items (backoff reaper, RabbitMQ RPC timeout) are deferred to a separate batch.

## Changes

**Await SCA payment status persistence** (`Http4sBGv13PIS.updatePaymentPsuDataAll`)
In the SCA-finalised branch, `saveTransactionRequestStatusImpl(...)` was nested inside `map`, so the status save ran fire-and-forget — the HTTP response could be built before `COMPLETED` was persisted. Changed `map` to `flatMap` so the save is awaited, aligning the branch type with the sibling `failed` branch (returns the save directly) and the default branch (`Future(Full(true))`). Mirrors the earlier `cancelPayment` fix.

**Redact JWT secret from DEBUG log** (`JwtUtil.verifyHmacSignedJwt`)
The entry DEBUG log printed the full consent JWT and its HMAC shared secret. Anyone with log-read access could forge consent JWTs. Removed the token and secret from the message. The later `signedJWT`/`verifier` debug lines never printed the secret and are unchanged.

**Raise default DB pool 10 → 20** (`CustomDBVendor`)
Each request holds its transaction connection for its whole lifetime, so `hikari.maximumPoolSize=10` exhausts at ~5 concurrent requests (rate-limit queries need a second connection). Raised the code default to 20; still prop-overridable so ops can tune higher.

## Verification

- `mvn install -pl .,obp-commons -am -DskipTests` (JDK 25 / zulu-25) — BUILD SUCCESS.
- `mvn compile -pl obp-api -am` (JDK 25) — BUILD SUCCESS, confirming the `flatMap` change type-checks across all three match branches.
- `git grep -n 'sharedSecret(' obp-api/src` — no hits; the secret is no longer logged.
