### PR TITLE
fix: self-heal backoff counter and RabbitMQ RPC timeout/promise bug

### DIFF
--- a/obp-api/src/main/scala/code/api/util/FutureUtil.scala
+++ b/obp-api/src/main/scala/code/api/util/FutureUtil.scala
@@ -70,18 +70,42 @@ object FutureUtil {
     p.future
   }
 
-  def futureWithLimits[T](future: Future[T], serviceName: String)(implicit ec: ExecutionContext): Future[T] = {
+  def futureWithLimits[T](future: Future[T], serviceName: String)(implicit ec: ExecutionContext): Future[T] =
+    futureWithLimits(future, serviceName, Constant.longEndpointTimeoutInMillis)
+
+  /**
+   * Bound the open-futures counter with a self-healing reaper.
+   *
+   * incrementFutureCounter runs synchronously; the matching decrement must run exactly once,
+   * no matter whether the wrapped Future completes, fails, or NEVER completes (e.g. a connector
+   * call to a hung backend). Without the reaper a never-completing Future keeps its slot in
+   * openFuturesCount forever, ratcheting getBackOffFactor to its worst tier (1024) so that
+   * canOpenFuture rejects ~all subsequent calls with ServiceIsTooBusy until the JVM restarts.
+   *
+   * The reaper only frees the accounting slot; the underlying Future is left untouched (giving
+   * the returned Future a timeout is a separate concern — see the RabbitMQ no-timeout finding).
+   * decrementOnce is guarded by an AtomicBoolean so the reaper and the Future's own completion
+   * can never decrement twice (which would drive the counter negative).
+   */
+  def futureWithLimits[T](future: Future[T], serviceName: String, reaperTimeoutMillis: Long)
+                         (implicit ec: ExecutionContext): Future[T] = {
     incrementFutureCounter(serviceName)
+
+    val decremented = new java.util.concurrent.atomic.AtomicBoolean(false)
+    def decrementOnce(): Unit =
+      if (decremented.compareAndSet(false, true)) decrementFutureCounter(serviceName)
+
+    val reaper = new TimerTask() {
+      def run(): Unit = decrementOnce()
+    }
+    timer.schedule(reaper, reaperTimeoutMillis)
+
+    future.onComplete { _ =>
+      reaper.cancel()
+      decrementOnce()
+    }
+
     future
-      .map(
-        value => {
-          decrementFutureCounter(serviceName)
-          value
-      }).recover{
-        case exception: Throwable =>
-          decrementFutureCounter(serviceName)
-          throw exception
-      }
   }
 
 }

--- a/obp-api/src/main/scala/code/bankconnectors/rabbitmq/RabbitMQUtils.scala
+++ b/obp-api/src/main/scala/code/bankconnectors/rabbitmq/RabbitMQUtils.scala
@@ -57,6 +57,10 @@ object RabbitMQUtils extends MdcLoggable{
   val RPC_QUEUE_NAME: String = APIUtil.getPropsValue("rabbitmq_connector.request_queue", "obp_rpc_queue")
   val RPC_REPLY_TO_QUEUE_NAME_PREFIX: String = APIUtil.getPropsValue("rabbitmq_connector.response_queue_prefix", "obp_reply_queue")
 
+  // Application-level cap on how long to wait for an adapter reply. Kept below the 60s reply-queue TTL/x-expires above.
+  val RABBITMQ_RESPONSE_TIMEOUT_IN_MILLIS: Long =
+    APIUtil.getPropsAsLongValue("rabbitmq_connector.response_timeout", code.api.Constant.longEndpointTimeoutInMillis)
+
   class ResponseCallback(val rabbitCorrelationId: String, channel: Channel) extends DeliverCallback {
 
     val promise = Promise[String]()
@@ -64,19 +68,16 @@ object RabbitMQUtils extends MdcLoggable{
 
     override def handle(consumerTag: String, message: Delivery): Unit = {
       if (message.getProperties.getCorrelationId.equals(rabbitCorrelationId)) {
-        {
-          promise.success {
-            val response =new String(message.getBody, "UTF-8");
-            try {
-              if (channel.isOpen) channel.close();
-            } catch {
-              case e: Throwable =>{
-                logger.debug(s"$AdapterUnknownError Can not close the channel properly! Details:$e")
-                throw new RuntimeException(s"$AdapterUnknownError Can not close the channel properly! Details:$e")
-              }
-            }
-            response
-          }
+        val response = new String(message.getBody, "UTF-8")
+        // Complete the promise BEFORE touching the channel. A channel-close failure must never
+        // prevent the waiting request from being satisfied, and must never escape onto the
+        // RabbitMQ dispatch thread. trySuccess is idempotent against duplicate deliveries.
+        promise.trySuccess(response)
+        try {
+          if (channel.isOpen) channel.close()
+        } catch {
+          case e: Throwable =>
+            logger.debug(s"$AdapterUnknownError Can not close the channel properly! Details:$e")
         }
       }
     }
@@ -146,7 +147,17 @@ object RabbitMQUtils extends MdcLoggable{
 
         val responseCallback = new ResponseCallback(rabbitMQCorrelationId, channel)
         channel.basicConsume(replyQueueName, true, responseCallback, cancelCallback)
-        responseCallback.take()
+        // Application-level timeout: if the adapter never replies, fail with 408 instead of hanging forever.
+        code.api.util.FutureUtil.futureWithTimeout(responseCallback.take())(
+          code.api.util.FutureUtil.EndpointTimeout(RABBITMQ_RESPONSE_TIMEOUT_IN_MILLIS),
+          code.api.util.FutureUtil.EndpointContext(None),
+          scala.concurrent.ExecutionContext.Implicits.global
+        ).andThen {
+          // On timeout/failure the ResponseCallback never ran, so the per-request channel is still open — release it.
+          case scala.util.Failure(_) =>
+            try { if (channel.isOpen) channel.close() }
+            catch { case e: Throwable => logger.debug(s"$AdapterUnknownError timeout channel cleanup failed: $e") }
+        }
       } catch {
         case e: RuntimeException if e.getMessage != null && e.getMessage.startsWith("OBP-") =>
           logger.debug(s"${RabbitMQConnector_vOct2024.toString} inBoundJson exception: $messageId = ${e}")

--- a/obp-api/src/test/scala/code/bankconnectors/rabbitmq/RabbitMQUtilsResponseCallbackTest.scala
+++ b/obp-api/src/test/scala/code/bankconnectors/rabbitmq/RabbitMQUtilsResponseCallbackTest.scala
@@ -1,0 +1,77 @@
+package code.bankconnectors.rabbitmq
+
+import com.rabbitmq.client.AMQP.BasicProperties
+import com.rabbitmq.client.{Channel, Delivery, Envelope}
+import org.scalatest.{FlatSpec, Matchers}
+
+import java.lang.reflect.{InvocationHandler, Method, Proxy}
+import java.util.UUID
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+/**
+ * O3: ResponseCallback.handle must complete the promise even when closing the channel fails.
+ *
+ * THE HAZARD (before the fix): `promise.success { ...; throw new RuntimeException(...) }` — the
+ * throw happens while evaluating the argument to `success`, so a channel-close failure meant the
+ * promise was never completed at all, and the exception escaped onto the RabbitMQ client dispatch
+ * thread. The fix completes the promise (`trySuccess`) BEFORE attempting to close the channel, so
+ * a close failure is merely logged and never blocks the waiting caller.
+ *
+ * No broker needed: `channel` is a dynamic proxy whose `close()` always throws, verifying the
+ * promise still resolves with the delivered message body.
+ */
+class RabbitMQUtilsResponseCallbackTest extends FlatSpec with Matchers {
+
+  private def channelWithFailingClose(): Channel = {
+    val handler = new InvocationHandler {
+      override def invoke(proxy: Any, method: Method, args: Array[AnyRef]): AnyRef = {
+        method.getName match {
+          case "isOpen"   => Boolean.box(true)
+          case "close"    => throw new java.io.IOException("simulated channel close failure")
+          case "hashCode" => Int.box(System.identityHashCode(proxy))
+          case "equals"   => Boolean.box(proxy eq (if (args != null) args(0) else null))
+          case "toString" => "FakeChannel"
+          case _          => null
+        }
+      }
+    }
+    Proxy.newProxyInstance(
+      classOf[Channel].getClassLoader,
+      Array(classOf[Channel]),
+      handler
+    ).asInstanceOf[Channel]
+  }
+
+  "ResponseCallback.handle" should "complete the promise with the message body even when channel.close() throws" in {
+    val correlationId = UUID.randomUUID().toString
+    val channel = channelWithFailingClose()
+    val callback = new RabbitMQUtils.ResponseCallback(correlationId, channel)
+
+    val properties = new BasicProperties.Builder().correlationId(correlationId).build()
+    val envelope = new Envelope(1L, false, "", "")
+    val body = "hello from adapter".getBytes("UTF-8")
+    val delivery = new Delivery(envelope, properties, body)
+
+    // Must not throw, even though channel.close() will fail internally.
+    callback.handle("consumer-tag", delivery)
+
+    val result = Await.result(callback.take(), 5.seconds)
+    result shouldBe "hello from adapter"
+  }
+
+  it should "ignore deliveries whose correlationId does not match (promise stays incomplete)" in {
+    val correlationId = UUID.randomUUID().toString
+    val otherCorrelationId = UUID.randomUUID().toString
+    val channel = channelWithFailingClose()
+    val callback = new RabbitMQUtils.ResponseCallback(correlationId, channel)
+
+    val properties = new BasicProperties.Builder().correlationId(otherCorrelationId).build()
+    val envelope = new Envelope(1L, false, "", "")
+    val delivery = new Delivery(envelope, properties, "irrelevant".getBytes("UTF-8"))
+
+    callback.handle("consumer-tag", delivery)
+
+    callback.promise.isCompleted shouldBe false
+  }
+}

--- a/obp-api/src/test/scala/code/concurrency/ConcurrentBackoffCounterSelfHealTest.scala
+++ b/obp-api/src/test/scala/code/concurrency/ConcurrentBackoffCounterSelfHealTest.scala
@@ -1,0 +1,85 @@
+package code.concurrency
+
+import code.api.util.{APIUtil, FutureUtil}
+import org.scalatest.{FlatSpec, Matchers}
+
+import java.util.UUID
+import scala.concurrent.{Await, Future, Promise}
+import scala.concurrent.duration._
+import scala.util.{Failure, Success, Try}
+
+/**
+ * A: futureWithLimits must self-heal the open-futures counter.
+ *
+ * THE HAZARD:
+ *   incrementFutureCounter runs synchronously; decrementFutureCounter only ran inside the
+ *   wrapped Future's .map/.recover. A Future that never completes (hung backend) never
+ *   decremented, so openFuturesCount for that service grew unbounded, ratcheting
+ *   APIUtil.getBackOffFactor to its worst tier (1024) — canOpenFuture's modulo check then
+ *   rejected ~all subsequent calls with ServiceIsTooBusy, permanently, until JVM restart.
+ *
+ * The fix adds a reaper TimerTask (3-arg futureWithLimits overload) that decrements the
+ * counter on a timeout ceiling if the wrapped Future hasn't completed by then, guarded by
+ * an AtomicBoolean so the reaper and the Future's own completion can never both decrement.
+ *
+ * This is a pure Future/counter test — it does not touch the DB or HTTP layer, so it does
+ * not extend ConcurrentRaceSetup/ServerSetupWithTestData (avoids an unnecessary full Lift
+ * server boot). Tagged ConcurrencyRace for consistency with the rest of the suite.
+ */
+class ConcurrentBackoffCounterSelfHealTest extends FlatSpec with Matchers {
+
+  private implicit val ec: scala.concurrent.ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
+
+  private def openFuturesCount(serviceName: String): Int =
+    APIUtil.serviceNameCountersMap.getOrDefault(serviceName, (0, 0))._2
+
+  "futureWithLimits" should "self-heal the open-futures counter when the wrapped Future never completes" taggedAs ConcurrencyRace in {
+    val serviceName = s"__conc_backoff_selfheal_${UUID.randomUUID.toString.take(8)}"
+    val neverCompletes = Promise[Unit]().future
+
+    FutureUtil.futureWithLimits(neverCompletes, serviceName, reaperTimeoutMillis = 200)
+    Thread.sleep(600)
+
+    withClue(s"openFuturesCount=${openFuturesCount(serviceName)} after reaper should have fired: ") {
+      openFuturesCount(serviceName) shouldBe 0
+    }
+    APIUtil.canOpenFuture(serviceName) shouldBe true
+  }
+
+  it should "not double-decrement when the underlying Future completes late, after the reaper already fired" taggedAs ConcurrencyRace in {
+    val serviceName = s"__conc_backoff_idempotent_${UUID.randomUUID.toString.take(8)}"
+    val promise = Promise[String]()
+
+    val wrapped = FutureUtil.futureWithLimits(promise.future, serviceName, reaperTimeoutMillis = 200)
+    Thread.sleep(400)
+    promise.success("late value")
+    Await.result(wrapped, 5.seconds)
+    // give the onComplete callback a moment to run after the promise resolved
+    Thread.sleep(200)
+
+    withClue(s"openFuturesCount=${openFuturesCount(serviceName)}: reaper and completion both firing must not double-decrement: ") {
+      openFuturesCount(serviceName) shouldBe 0
+    }
+  }
+
+  it should "behave exactly like the original Future when it completes immediately (no regression)" taggedAs ConcurrencyRace in {
+    val serviceNameOk = s"__conc_backoff_ok_${UUID.randomUUID.toString.take(8)}"
+    val serviceNameFail = s"__conc_backoff_fail_${UUID.randomUUID.toString.take(8)}"
+
+    val okResult = Try(Await.result(FutureUtil.futureWithLimits(Future.successful("ok"), serviceNameOk, reaperTimeoutMillis = 5000), 5.seconds))
+    val failResult = Try(Await.result(FutureUtil.futureWithLimits(Future.failed[String](new RuntimeException("boom")), serviceNameFail, reaperTimeoutMillis = 5000), 5.seconds))
+
+    okResult shouldBe Success("ok")
+    failResult match {
+      case Failure(e) => e.getMessage shouldBe "boom"
+      case Success(_) => fail("expected the failed Future to propagate its failure")
+    }
+
+    withClue(s"openFuturesCount(ok)=${openFuturesCount(serviceNameOk)}: ") {
+      openFuturesCount(serviceNameOk) shouldBe 0
+    }
+    withClue(s"openFuturesCount(fail)=${openFuturesCount(serviceNameFail)}: ") {
+      openFuturesCount(serviceNameFail) shouldBe 0
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Backoff counter self-heal: `futureWithLimits` now schedules a reaper `TimerTask` that decrements the open-futures counter if the wrapped Future never completes, so a hung connector call can no longer permanently ratchet `getBackOffFactor` to its worst tier and lock out `canOpenFuture` for that service until JVM restart. The 2-arg overload used by existing StarConnector call sites is unchanged; a new 3-arg overload takes an explicit reaper timeout.
- RabbitMQ RPC reply timeout + promise-never-completes fix: `ResponseCallback.handle` now completes the promise with `trySuccess` before attempting to close the channel, so a channel-close failure can no longer leave the promise permanently incomplete or throw onto the RabbitMQ dispatch thread. The RPC reply wait is also wrapped in `FutureUtil.futureWithTimeout`, bounded by a new `rabbitmq_connector.response_timeout` prop (default: existing `long_endpoint_timeout`), so a silent adapter fails the call instead of hanging forever; the per-request channel is closed on timeout to release it.

## Test plan
- [x] `mvn install -pl .,obp-commons -am -DskipTests` — BUILD SUCCESS
- [x] `mvn test-compile -pl obp-api` — compiles clean with both fixes
- [x] New test `ConcurrentBackoffCounterSelfHealTest` (3 scenarios: self-heal, no-double-decrement, no-regression on immediate completion) — all pass
- [x] New test `RabbitMQUtilsResponseCallbackTest` (O3 regression: promise completes even when `channel.close()` throws; non-matching correlationId leaves promise incomplete) — all pass
- [x] `git grep -n 'futureWithLimits\b'` confirms both existing StarConnector call sites (`bankconnectors/package.scala:59,151`) still compile unchanged against the preserved 2-arg overload
- [ ] Broker-backed integration tests for the RabbitMQ timeout path (testcontainers, requires Docker) were not run in this environment pass — the O3 unit test covers the promise-completion bug directly; the timeout wrapper itself compiles against `FutureUtil.futureWithTimeout`'s existing signature unchanged