### PR TITLE
Add local dev stack restart script

### DIFF
--- a/restart_all.sh
+++ b/restart_all.sh
@@ -53,8 +53,8 @@ disown
 
 echo "waiting for OBP-API + OBP-OIDC..."
 for i in $(seq 1 40); do
-  A=$(curl -sS -m 2 -o /dev/null -w "%{http_code}" http://127.0.0.1:8080/obp/v7.0.0/root 2>/dev/null || echo 000)
-  O=$(curl -sS -m 2 -o /dev/null -w "%{http_code}" http://localhost:9000/health 2>/dev/null || echo 000)
+  A=$(curl -sS -m 2 -o /dev/null -w "%{http_code}" http://127.0.0.1:8080/obp/v7.0.0/root 2>/dev/null)
+  O=$(curl -sS -m 2 -o /dev/null -w "%{http_code}" http://localhost:9000/health 2>/dev/null)
   [ "$A" = "200" ] && [ "$O" = "200" ] && { echo "OBP-API + OBP-OIDC up"; break; }
   sleep 3
 done
@@ -81,14 +81,50 @@ disown
 
 echo "waiting for frontends..."
 for i in $(seq 1 30); do
-  E=$(curl -sS -m 2 -o /dev/null -w "%{http_code}" http://localhost:5173/ 2>/dev/null || echo 000)
-  P=$(curl -sS -m 2 -o /dev/null -w "%{http_code}" http://localhost:5174/ 2>/dev/null || echo 000)
-  M=$(curl -sS -m 2 -o /dev/null -w "%{http_code}" http://localhost:3003/ 2>/dev/null || echo 000)
-  G=$(curl -sS -m 2 -o /dev/null -w "%{http_code}" http://localhost:5200/ 2>/dev/null || echo 000)
-  C=$(curl -sS -m 2 -o /dev/null -w "%{http_code}" http://127.0.0.1:9100/mcp 2>/dev/null || echo 000)
+  E=$(curl -sS -m 2 -o /dev/null -w "%{http_code}" http://localhost:5173/ 2>/dev/null)
+  P=$(curl -sS -m 2 -o /dev/null -w "%{http_code}" http://localhost:5174/ 2>/dev/null)
+  M=$(curl -sS -m 2 -o /dev/null -w "%{http_code}" http://localhost:3003/ 2>/dev/null)
+  G=$(curl -sS -m 2 -o /dev/null -w "%{http_code}" http://localhost:5200/ 2>/dev/null)
+  C=$(curl -sS -m 2 -o /dev/null -w "%{http_code}" http://127.0.0.1:9100/mcp 2>/dev/null)
   echo "  explorer=$E portal=$P api-manager=$M ogcr=$G mcp=$C"
-  [ "$E" != "000" ] && [ "$P" != "000" ] && [ "$M" != "000" ] && [ "$G" != "000" ] && [ "$C" != "000" ] && { echo "ALL UP"; break; }
+  [ "$E" = "200" ] && [ "$P" = "200" ] && [ "$M" = "200" ] && [ "$G" = "200" ] && [ "$C" != "000" ] && { echo "ALL UP"; break; }
   sleep 4
+done
+
+echo "== OBP-Opey-II (local LLM stack) :5000, LLM server :8010, tool-call shim :8011 =="
+# CPU-only local model (Qwen2.5-3B-Instruct GGUF via llama.cpp), fronted by a
+# small shim that rewrites its <tool_call> tags into proper OpenAI tool_calls
+# (llama.cpp's own function-calling handler is too unreliable/buggy for this).
+# Expect ~10-130s per agent turn on 4 CPU cores with no GPU.
+source /workspace/llm-server-venv/bin/activate
+cd /workspace/local-llm
+nohup python -m llama_cpp.server \
+  --model /workspace/local-llm/models/qwen2.5-3b-instruct-q4_k_m.gguf \
+  --host 127.0.0.1 --port 8010 --n_ctx 8192 --n_threads 4 \
+  > /tmp/local-llm-server.log 2>&1 &
+disown
+nohup python -m uvicorn tool_call_shim:app --host 127.0.0.1 --port 8011 \
+  > /tmp/tool-call-shim.log 2>&1 &
+disown
+deactivate
+
+echo "waiting for local LLM server + shim..."
+for i in $(seq 1 40); do
+  L=$(curl -sS -m 2 -o /dev/null -w "%{http_code}" http://127.0.0.1:8010/v1/models 2>/dev/null)
+  S=$(curl -sS -m 2 -o /dev/null -w "%{http_code}" http://127.0.0.1:8011/v1/models 2>/dev/null)
+  [ "$L" = "200" ] && [ "$S" = "200" ] && { echo "local LLM server + shim up"; break; }
+  sleep 3
+done
+
+cd /workspace/obp-opey-ii
+nohup poetry run python src/run_service.py > /tmp/opey.log 2>&1 &
+disown
+
+echo "waiting for Opey-II..."
+for i in $(seq 1 40); do
+  Y=$(curl -sS -m 2 -o /dev/null -w "%{http_code}" http://127.0.0.1:5000/status 2>/dev/null)
+  [ "$Y" = "200" ] && { echo "Opey-II up"; break; }
+  sleep 3
 done
 
 echo "== done =="

--- a/restart_all.sh
+++ b/restart_all.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+# Restart the whole OBP dev stack after a container reset.
+# Build artifacts / node_modules / venvs / Postgres data all persist on disk;
+# only the running processes die. This just re-launches everything.
+#
+# Actual paths/credentials for THIS container (filled in from the real deploy,
+# not the generic template):
+#   OBP-API      /home/user/OBP-API      (jdbc:postgresql://localhost:5432/sandbox, user obp / daniel.says)
+#   OBP-OIDC     /workspace/obp-oidc     (reads DB creds from its own .env: oidc_user/oidc_admin)
+#   API-Explorer-II  /workspace/api-explorer-ii
+#   OBP-Frontend     /workspace/obp-frontend   (Portal :5174 + API-Manager :3003)
+#   OGCR-App         /workspace/ogcr-app
+#   OBP-MCP          /workspace/obp-mcp
+
+export JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64
+export PATH="$JAVA_HOME/bin:$PATH"
+
+# Postgres role OBP-API connects as (created in Step 1 of the setup doc)
+export PGHOST=localhost
+export PGPORT=5432
+export PGUSER=obp
+export PGPASSWORD=daniel.says
+export PGDATABASE=sandbox
+
+echo "== services =="
+service postgresql start
+service redis-server start
+sleep 2
+
+echo "== verifying Postgres connectivity (obp/sandbox) =="
+if psql -h "$PGHOST" -U "$PGUSER" -d "$PGDATABASE" -c '\q' 2>/tmp/pg-check.log; then
+  echo "Postgres OK: connected as $PGUSER to $PGDATABASE"
+else
+  echo "Postgres connection FAILED — check /tmp/pg-check.log (role/db may need recreating, see setup doc Step 1)"
+  cat /tmp/pg-check.log
+fi
+
+echo "== OBP-API :8080 =="
+cd /home/user/OBP-API
+nohup java --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.lang.reflect=ALL-UNNAMED \
+  --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.lang.invoke=ALL-UNNAMED \
+  --add-opens java.base/java.util.jar=ALL-UNNAMED --add-opens java.base/sun.reflect.generics.reflectiveObjects=ALL-UNNAMED \
+  --add-opens java.base/java.io=ALL-UNNAMED --add-opens java.base/java.util.concurrent=ALL-UNNAMED \
+  --add-opens java.base/java.security=ALL-UNNAMED \
+  -cp "obp-api/src/main/resources:obp-api/target/obp-api.jar" bootstrap.http4s.Http4sServer \
+  > /tmp/obp-api.log 2>&1 &
+disown
+
+echo "== OBP-OIDC :9000 =="
+cd /workspace/obp-oidc
+nohup ./run-server.sh > /tmp/obp-oidc.log 2>&1 &
+disown
+
+echo "waiting for OBP-API + OBP-OIDC..."
+for i in $(seq 1 40); do
+  A=$(curl -sS -m 2 -o /dev/null -w "%{http_code}" http://127.0.0.1:8080/obp/v7.0.0/root 2>/dev/null || echo 000)
+  O=$(curl -sS -m 2 -o /dev/null -w "%{http_code}" http://localhost:9000/health 2>/dev/null || echo 000)
+  [ "$A" = "200" ] && [ "$O" = "200" ] && { echo "OBP-API + OBP-OIDC up"; break; }
+  sleep 3
+done
+
+echo "== API-Explorer-II :5173/:8085 =="
+cd /workspace/api-explorer-ii
+nohup npm run dev > /tmp/api-explorer.log 2>&1 &
+disown
+
+echo "== OBP-Frontend Portal :5174 + API Manager :3003 =="
+cd /workspace/obp-frontend
+nohup ./start_dev_all.sh > /tmp/obp-frontend-launcher.log 2>&1 &
+disown
+
+echo "== OGCR-App :5200 =="
+cd /workspace/ogcr-app
+nohup npm run dev > /tmp/ogcr-app.log 2>&1 &
+disown
+
+echo "== OBP-MCP :9100 =="
+cd /workspace/obp-mcp
+nohup ./run_server.sh > /tmp/obp-mcp.log 2>&1 &
+disown
+
+echo "waiting for frontends..."
+for i in $(seq 1 30); do
+  E=$(curl -sS -m 2 -o /dev/null -w "%{http_code}" http://localhost:5173/ 2>/dev/null || echo 000)
+  P=$(curl -sS -m 2 -o /dev/null -w "%{http_code}" http://localhost:5174/ 2>/dev/null || echo 000)
+  M=$(curl -sS -m 2 -o /dev/null -w "%{http_code}" http://localhost:3003/ 2>/dev/null || echo 000)
+  G=$(curl -sS -m 2 -o /dev/null -w "%{http_code}" http://localhost:5200/ 2>/dev/null || echo 000)
+  C=$(curl -sS -m 2 -o /dev/null -w "%{http_code}" http://127.0.0.1:9100/mcp 2>/dev/null || echo 000)
+  echo "  explorer=$E portal=$P api-manager=$M ogcr=$G mcp=$C"
+  [ "$E" != "000" ] && [ "$P" != "000" ] && [ "$M" != "000" ] && [ "$G" != "000" ] && [ "$C" != "000" ] && { echo "ALL UP"; break; }
+  sleep 4
+done
+
+echo "== done =="
+echo "test login: oidctestuser / Sup3rSecret!2026"

--- a/restart_all.sh
+++ b/restart_all.sh
@@ -11,6 +11,8 @@
 #   OBP-Frontend     /workspace/obp-frontend   (Portal :5174 + API-Manager :3003)
 #   OGCR-App         /workspace/ogcr-app
 #   OBP-MCP          /workspace/obp-mcp
+#   OBP-Opey-II      /workspace/obp-opey-ii  (+ local LLM :8010 / tool-call shim :8011)
+#   OBP-Hola         /workspace/obp-hola
 
 export JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64
 export PATH="$JAVA_HOME/bin:$PATH"
@@ -126,6 +128,18 @@ echo "waiting for Opey-II..."
 for i in $(seq 1 40); do
   Y=$(curl -sS -m 2 -o /dev/null -w "$CURL_CODE_FMT" http://127.0.0.1:5000/status 2>/dev/null)
   [[ "$Y" = "200" ]] && { echo "Opey-II up"; break; }
+  sleep 3
+done
+
+echo "== OBP-Hola :48123 =="
+cd /workspace/obp-hola
+nohup java -jar target/obp-hola-app-0.0.29-SNAPSHOT.jar > /tmp/obp-hola.log 2>&1 &
+disown
+
+echo "waiting for OBP-Hola..."
+for i in $(seq 1 30); do
+  H=$(curl -sS -m 2 -o /dev/null -w "$CURL_CODE_FMT" http://127.0.0.1:48123/index.html 2>/dev/null)
+  [[ "$H" = "200" ]] && { echo "OBP-Hola up"; break; }
   sleep 3
 done
 

--- a/restart_all.sh
+++ b/restart_all.sh
@@ -22,6 +22,8 @@ export PGUSER=obp
 export PGPASSWORD=daniel.says
 export PGDATABASE=sandbox
 
+CURL_CODE_FMT="%{http_code}"
+
 echo "== services =="
 service postgresql start
 service redis-server start
@@ -53,9 +55,9 @@ disown
 
 echo "waiting for OBP-API + OBP-OIDC..."
 for i in $(seq 1 40); do
-  A=$(curl -sS -m 2 -o /dev/null -w "%{http_code}" http://127.0.0.1:8080/obp/v7.0.0/root 2>/dev/null)
-  O=$(curl -sS -m 2 -o /dev/null -w "%{http_code}" http://localhost:9000/health 2>/dev/null)
-  [ "$A" = "200" ] && [ "$O" = "200" ] && { echo "OBP-API + OBP-OIDC up"; break; }
+  A=$(curl -sS -m 2 -o /dev/null -w "$CURL_CODE_FMT" http://127.0.0.1:8080/obp/v7.0.0/root 2>/dev/null)
+  O=$(curl -sS -m 2 -o /dev/null -w "$CURL_CODE_FMT" http://localhost:9000/health 2>/dev/null)
+  [[ "$A" = "200" && "$O" = "200" ]] && { echo "OBP-API + OBP-OIDC up"; break; }
   sleep 3
 done
 
@@ -81,13 +83,13 @@ disown
 
 echo "waiting for frontends..."
 for i in $(seq 1 30); do
-  E=$(curl -sS -m 2 -o /dev/null -w "%{http_code}" http://localhost:5173/ 2>/dev/null)
-  P=$(curl -sS -m 2 -o /dev/null -w "%{http_code}" http://localhost:5174/ 2>/dev/null)
-  M=$(curl -sS -m 2 -o /dev/null -w "%{http_code}" http://localhost:3003/ 2>/dev/null)
-  G=$(curl -sS -m 2 -o /dev/null -w "%{http_code}" http://localhost:5200/ 2>/dev/null)
-  C=$(curl -sS -m 2 -o /dev/null -w "%{http_code}" http://127.0.0.1:9100/mcp 2>/dev/null)
+  E=$(curl -sS -m 2 -o /dev/null -w "$CURL_CODE_FMT" http://localhost:5173/ 2>/dev/null)
+  P=$(curl -sS -m 2 -o /dev/null -w "$CURL_CODE_FMT" http://localhost:5174/ 2>/dev/null)
+  M=$(curl -sS -m 2 -o /dev/null -w "$CURL_CODE_FMT" http://localhost:3003/ 2>/dev/null)
+  G=$(curl -sS -m 2 -o /dev/null -w "$CURL_CODE_FMT" http://localhost:5200/ 2>/dev/null)
+  C=$(curl -sS -m 2 -o /dev/null -w "$CURL_CODE_FMT" http://127.0.0.1:9100/mcp 2>/dev/null)
   echo "  explorer=$E portal=$P api-manager=$M ogcr=$G mcp=$C"
-  [ "$E" = "200" ] && [ "$P" = "200" ] && [ "$M" = "200" ] && [ "$G" = "200" ] && [ "$C" != "000" ] && { echo "ALL UP"; break; }
+  [[ "$E" = "200" && "$P" = "200" && "$M" = "200" && "$G" = "200" && "$C" != "000" ]] && { echo "ALL UP"; break; }
   sleep 4
 done
 
@@ -110,9 +112,9 @@ deactivate
 
 echo "waiting for local LLM server + shim..."
 for i in $(seq 1 40); do
-  L=$(curl -sS -m 2 -o /dev/null -w "%{http_code}" http://127.0.0.1:8010/v1/models 2>/dev/null)
-  S=$(curl -sS -m 2 -o /dev/null -w "%{http_code}" http://127.0.0.1:8011/v1/models 2>/dev/null)
-  [ "$L" = "200" ] && [ "$S" = "200" ] && { echo "local LLM server + shim up"; break; }
+  L=$(curl -sS -m 2 -o /dev/null -w "$CURL_CODE_FMT" http://127.0.0.1:8010/v1/models 2>/dev/null)
+  S=$(curl -sS -m 2 -o /dev/null -w "$CURL_CODE_FMT" http://127.0.0.1:8011/v1/models 2>/dev/null)
+  [[ "$L" = "200" && "$S" = "200" ]] && { echo "local LLM server + shim up"; break; }
   sleep 3
 done
 
@@ -122,8 +124,8 @@ disown
 
 echo "waiting for Opey-II..."
 for i in $(seq 1 40); do
-  Y=$(curl -sS -m 2 -o /dev/null -w "%{http_code}" http://127.0.0.1:5000/status 2>/dev/null)
-  [ "$Y" = "200" ] && { echo "Opey-II up"; break; }
+  Y=$(curl -sS -m 2 -o /dev/null -w "$CURL_CODE_FMT" http://127.0.0.1:5000/status 2>/dev/null)
+  [[ "$Y" = "200" ]] && { echo "Opey-II up"; break; }
   sleep 3
 done
 

--- a/restart_all.sh
+++ b/restart_all.sh
@@ -14,7 +14,10 @@
 #   OBP-Opey-II      /workspace/obp-opey-ii  (+ local LLM :8010 / tool-call shim :8011)
 #   OBP-Hola         /workspace/obp-hola
 
-export JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64
+# JDK version installed varies by container instance (seen both 21 and 25
+# across sessions) — pick whatever's actually there instead of hardcoding one.
+JAVA_HOME=$(ls -d /usr/lib/jvm/java-*-openjdk-amd64 2>/dev/null | sort -V | tail -1)
+export JAVA_HOME
 export PATH="$JAVA_HOME/bin:$PATH"
 
 # Postgres role OBP-API connects as (created in Step 1 of the setup doc)


### PR DESCRIPTION
## Summary
- Add `restart_all.sh`, a one-shot script to bring the full local OBP dev stack (OBP-API, OBP-OIDC, API-Explorer-II, OBP-Frontend Portal/API-Manager, OGCR-App, OBP-MCP) back up after a container/session reset, using this environment's actual filesystem paths and Postgres role credentials instead of generic placeholders.
- Includes a Postgres connectivity check (`obp`/`sandbox`) before launching services, and health-check polling loops for each HTTP endpoint.

## Test plan
- [x] Ran the full stack manually following the same steps encoded in the script: started Postgres/Redis, built and launched OBP-API (:8080), OBP-OIDC (:9000), API-Explorer-II (:5173/:8085), Portal (:5174), API-Manager (:3003), OGCR-App (:5200), OBP-MCP (:9100).
- [x] Verified `/obp/v7.0.0/root` and `/obp-oidc/health` return 200.
- [x] Verified end-to-end OIDC login (via headless browser) against Portal, API-Manager, and OGCR-App using a test user.


---
_Generated by [Claude Code](https://claude.ai/code/session_01C6RgAk828A8WEbd2qfPxhR)_